### PR TITLE
Resolve/reject promise with response information

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,9 +92,15 @@ function sendNotification(endpoint, TTL, userPublicKey, payload) {
       if (pushResponse.statusCode !== expectedStatusCode) {
         console.log('statusCode: ', pushResponse.statusCode);
         console.log('headers: ', pushResponse.headers);
-        reject();
+        reject(pushResponse.statusCode);
       } else {
-        resolve();
+        var body = "";
+        pushResponse.on('data', function(chunk) {
+          body += chunk;
+        });
+        pushResponse.on('end', function() {
+          resolve(body);
+        });
       }
     });
 

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ function sendNotification(endpoint, TTL, userPublicKey, payload) {
       if (pushResponse.statusCode !== expectedStatusCode) {
         console.log('statusCode: ', pushResponse.statusCode);
         console.log('headers: ', pushResponse.headers);
-        reject(pushResponse.statusCode);
+        reject(new WebPushError('Received unexpected response code', pushResponse.statusCode));
       } else {
         var body = "";
         pushResponse.on('data', function(chunk) {
@@ -133,4 +133,4 @@ module.exports = {
   encrypt: encrypt,
   sendNotification: sendNotification,
   setGCMAPIKey: setGCMAPIKey,
-}
+};

--- a/test/tests/testSendNotification.js
+++ b/test/tests/testSendNotification.js
@@ -170,6 +170,8 @@ suite('sendNotification', function() {
     .then(function() {
       assert(false, 'sendNotification promise resolved');
     }, function() {
+      assert(err instanceof webPush.WebPushError, 'err is a WebPushError');
+      assert(err.statusCode, 404);
       assert(true, 'sendNotification promise rejected');
     });
   });

--- a/test/tests/testSendNotification.js
+++ b/test/tests/testSendNotification.js
@@ -169,7 +169,7 @@ suite('sendNotification', function() {
     })
     .then(function() {
       assert(false, 'sendNotification promise resolved');
-    }, function() {
+    }, function(err) {
       assert(err instanceof webPush.WebPushError, 'err is a WebPushError');
       assert(err.statusCode, 404);
       assert(true, 'sendNotification promise rejected');


### PR DESCRIPTION
Fixes #56.

This pull makes web-push return the pushResponse information from the push server.  This is important particularly for GCM where important information like a missing gcm api key, or invalid registration endpoint, are returned as part of the response body.