### PR TITLE
Add new GCM Endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function sendNotification(endpoint, TTL, userPublicKey, payload) {
     }
 
     var gcmPayload;
-    if (endpoint.indexOf('https://android.googleapis.com/gcm/send') === 0) {
+    if (endpoint.indexOf('https://android.googleapis.com/gcm/send') === 0 || endpoint.indexOf('https://gcm-http.googleapis.com/gcm/send' === 0)) {
       if (payload) {
         reject(new WebPushError('Payload not supported with GCM'));
         return;


### PR DESCRIPTION
Google changed the endpoint to `https://gcm-http.googleapis.com/gcm/send` [here](https://developers.google.com/cloud-messaging/). My PR adds a check for the new endpoint.

I didn't touch the tests as I did this directly from Github. I can change the current endpoint to the new one if you'd like.