### PR TITLE
Use standard base64 in the raw_data field of the GCM payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ function sendNotification(endpoint, params) {
           registration_ids: [ subscriptionId ],
         };
         if (encrypted) {
-          gcmObj['raw_data'] = urlBase64.encode(encrypted.cipherText);
+          gcmObj['raw_data'] = encrypted.cipherText.toString('base64');
         }
         gcmPayload = JSON.stringify(gcmObj);
 


### PR DESCRIPTION
Fixes #117.