### PR TITLE
Support new encryption standards for newer Firefox versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "asn1.js": "^4.5.2",
     "colors": "^1.1.2",
-    "http_ece": "^0.4.4",
+    "http_ece": "https://github.com/marco-c/http_ece_unstable/tarball/75a174d4c92b4953527face35d02fc8f4cd8e60a",
     "jws": "^3.1.3",
     "urlsafe-base64": "^1.0.0"
   },


### PR DESCRIPTION
Fixes #120.

Depends on https://github.com/martinthomson/encrypted-content-encoding/pull/18.