### PR TITLE
Update selenium webdriver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
     - MOZ_XVFB=$(if [[ $TRAVIS_OS_NAME == "linux" ]]; then echo 1; fi)
   matrix:
     - NODE_VERSION="0.12"
-    - NODE_VERSION="4" FIREFOX="all" CHROME="nightly"
-    - NODE_VERSION="stable" FIREFOX="all" CHROME="nightly"
+    - NODE_VERSION="4" CHROME="nightly"
+    - NODE_VERSION="stable" CHROME="nightly"
 before_install:
   - rm -rf ~/.nvm
   - git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Supports Firefox 44+ and Chromium/Chrome 42+.
 Notifications with payloads are supported in Firefox 44+ and Chromium/Chrome 50+.
-[VAPID](https://tools.ietf.org/html/draft-thomson-webpush-vapid-02) is supported in Firefox 45+ (for notifications without payloads) and in Firefox 46+ for all notifications.
+[VAPID](https://tools.ietf.org/html/draft-thomson-webpush-vapid-02) is supported in Firefox 45+ (for notifications without payloads).
 
 [![NPM](https://nodei.co/npm/web-push.svg?downloads=true)](https://www.npmjs.com/package/web-push)
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mocha": "^2.4.5",
     "portfinder": "^1.0.2",
     "request": "^2.69.0",
-    "selenium-webdriver": "2.52.0",
+    "selenium-webdriver": "^2.53.1",
     "semver": "^5.1.0",
     "temp": "^0.8.3"
   }

--- a/test/server.js
+++ b/test/server.js
@@ -51,11 +51,6 @@ function createServer(pushPayload, pushTimeout, vapid) {
 
         console.log('Push Application Server - Register: ' + obj.endpoint);
 
-        server.clientRegistered = true;
-        if (server.onClientRegistered && server.onClientRegistered()) {
-          return;
-        }
-
         setTimeout(function() {
           console.log('Push Application Server - Send notification to ' + obj.endpoint);
 
@@ -78,11 +73,6 @@ function createServer(pushPayload, pushTimeout, vapid) {
           promise
           .then(function() {
             console.log('Push Application Server - Notification sent to ' + obj.endpoint);
-
-            server.notificationSent = true;
-            if (server.onNotificationSent) {
-              server.onNotificationSent();
-            }
           });
         }, pushTimeout * 1000);
       });
@@ -105,9 +95,6 @@ function createServer(pushPayload, pushTimeout, vapid) {
     }
     server.listen(server.port);
   });
-
-  server.notificationSent = false;
-  server.clientRegistered = false;
 
   return new Promise(function(resolve, reject) {
     server.on('listening', function() {

--- a/test/server.js
+++ b/test/server.js
@@ -51,30 +51,26 @@ function createServer(pushPayload, pushTimeout, vapid) {
 
         console.log('Push Application Server - Register: ' + obj.endpoint);
 
-        setTimeout(function() {
-          console.log('Push Application Server - Send notification to ' + obj.endpoint);
+        console.log('Push Application Server - Send notification to ' + obj.endpoint);
 
-          var promise;
-          if (!pushPayload) {
-            promise = webPush.sendNotification(obj.endpoint, {
-              TTL: pushTimeout ? 200 : undefined,
-              vapid: vapid,
-            });
-          } else {
-            promise = webPush.sendNotification(obj.endpoint, {
-              TTL: pushTimeout ? 200 : undefined,
-              payload: pushPayload,
-              userPublicKey: obj.key,
-              userAuth: obj.auth,
-              vapid: vapid,
-            });
-          }
-
-          promise
-          .then(function() {
-            console.log('Push Application Server - Notification sent to ' + obj.endpoint);
+        var promise;
+        if (!pushPayload) {
+          promise = webPush.sendNotification(obj.endpoint, {
+            vapid: vapid,
           });
-        }, pushTimeout * 1000);
+        } else {
+          promise = webPush.sendNotification(obj.endpoint, {
+            payload: pushPayload,
+            userPublicKey: obj.key,
+            userAuth: obj.auth,
+            vapid: vapid,
+          });
+        }
+
+        promise
+        .then(function() {
+          console.log('Push Application Server - Notification sent to ' + obj.endpoint);
+        });
       });
 
       res.writeHead(200, {

--- a/test/server.js
+++ b/test/server.js
@@ -18,7 +18,7 @@ var options = {
   cert: pem,
 };
 
-function createServer(pushPayload, pushTimeout, vapid) {
+function createServer(pushPayload, vapid) {
   var server = https.createServer(options, function(req, res) {
     if (req.method === 'GET') {
       if (req.url === '/') {
@@ -70,7 +70,11 @@ function createServer(pushPayload, pushTimeout, vapid) {
         promise
         .then(function() {
           console.log('Push Application Server - Notification sent to ' + obj.endpoint);
-        });
+        })
+        .catch(function(error) {
+          console.log('Push Application Server - Error in sending notification to ' + obj.endpoint);
+          console.log(error);
+        })
       });
 
       res.writeHead(200, {

--- a/test/testSelenium.js
+++ b/test/testSelenium.js
@@ -6,9 +6,6 @@ var temp = require('temp').track();
 var colors = require('colors');
 var semver = require('semver');
 var childProcess = require('child_process');
-var webdriver = require('selenium-webdriver');
-var firefox = require('selenium-webdriver/firefox');
-var chrome = require('selenium-webdriver/chrome');
 var seleniumInit = require('./selenium-init');
 var createServer = require('./server');
 var webPush = require('../index.js');
@@ -24,6 +21,10 @@ suite('selenium', function() {
     console.log('selenium-webdriver is incompatible with Node.js v0.12');
     return;
   }
+
+  var webdriver = require('selenium-webdriver');
+  var firefox = require('selenium-webdriver/firefox');
+  var chrome = require('selenium-webdriver/chrome');
 
   this.timeout(180000);
 

--- a/test/testSelenium.js
+++ b/test/testSelenium.js
@@ -27,8 +27,6 @@ suite('selenium', function() {
 
   this.timeout(180000);
 
-  var profilePath = temp.mkdirSync('marco');
-
   var firefoxStableBinaryPath, firefoxBetaBinaryPath, chromeBinaryPath;
   var server, driver;
 
@@ -50,6 +48,8 @@ suite('selenium', function() {
     return createServer(payload, vapid)
     .then(function(newServer) {
       server = newServer;
+
+      var profilePath = temp.mkdirSync('marco');
 
       var profile = new firefox.Profile(profilePath);
       profile.acceptUntrustedCerts();

--- a/test/testSelenium.js
+++ b/test/testSelenium.js
@@ -27,7 +27,7 @@ suite('selenium', function() {
 
   this.timeout(180000);
 
-  var firefoxStableBinaryPath, firefoxBetaBinaryPath, chromeBinaryPath;
+  var firefoxStableBinaryPath, firefoxBetaBinaryPath, firefoxNightlyBinaryPath, chromeBinaryPath;
   var server, driver;
 
   function runTest(params) {
@@ -98,32 +98,29 @@ suite('selenium', function() {
 
     var promises = [];
 
-    firefoxBinaryPath = process.env.FIREFOX;
-    if (firefoxBinaryPath === 'nightly') {
-      if (process.platform === 'linux') {
-        firefoxBinaryPath = 'test_tools/firefox/firefox-bin';
-      } else if (process.platform === 'darwin') {
-        firefoxBinaryPath = 'test_tools/FirefoxNightly.app/Contents/MacOS/firefox-bin';
-      }
-
-      promises.push(seleniumInit.downloadFirefoxNightly());
-    } else if (firefoxBinaryPath === 'all') {
-      if (process.platform === 'linux') {
-        firefoxStableBinaryPath = 'test_tools/stable/firefox/firefox-bin';
-      } else if (process.platform === 'darwin') {
-        firefoxStableBinaryPath = 'test_tools/stable/Firefox.app/Contents/MacOS/firefox-bin';
-      }
-
-      promises.push(seleniumInit.downloadFirefoxRelease());
-
-      if (process.platform === 'linux') {
-        firefoxBetaBinaryPath = 'test_tools/beta/firefox/firefox-bin';
-      } else if (process.platform === 'darwin') {
-        firefoxBetaBinaryPath = 'test_tools/beta/Firefox.app/Contents/MacOS/firefox-bin';
-      }
-
-      promises.push(seleniumInit.downloadFirefoxBeta());
+    if (process.platform === 'linux') {
+      firefoxStableBinaryPath = 'test_tools/stable/firefox/firefox-bin';
+    } else if (process.platform === 'darwin') {
+      firefoxStableBinaryPath = 'test_tools/stable/Firefox.app/Contents/MacOS/firefox-bin';
     }
+
+    promises.push(seleniumInit.downloadFirefoxRelease());
+
+    if (process.platform === 'linux') {
+      firefoxBetaBinaryPath = 'test_tools/beta/firefox/firefox-bin';
+    } else if (process.platform === 'darwin') {
+      firefoxBetaBinaryPath = 'test_tools/beta/Firefox.app/Contents/MacOS/firefox-bin';
+    }
+
+    promises.push(seleniumInit.downloadFirefoxBeta());
+
+    if (process.platform === 'linux') {
+      firefoxNightlyBinaryPath = 'test_tools/firefox/firefox-bin';
+    } else if (process.platform === 'darwin') {
+      firefoxNightlyBinaryPath = 'test_tools/FirefoxNightly.app/Contents/MacOS/firefox-bin';
+    }
+
+    promises.push(seleniumInit.downloadFirefoxNightly());
 
     try {
       console.log('Using Firefox: ' + firefoxStableBinaryPath);

--- a/test/testSelenium.js
+++ b/test/testSelenium.js
@@ -33,7 +33,7 @@ suite('selenium', function() {
   function runTest(params) {
     var firefoxBinaryPath;
     if (params.browser === 'firefox') {
-      firefoxBinaryPath = firefoxStableBinaryPath
+      firefoxBinaryPath = firefoxStableBinaryPath;
     } else if (params.browser === 'firefox-beta') {
       params.browser = 'firefox';
       firefoxBinaryPath = firefoxBetaBinaryPath;
@@ -109,9 +109,9 @@ suite('selenium', function() {
       promises.push(seleniumInit.downloadFirefoxNightly());
     } else if (firefoxBinaryPath === 'all') {
       if (process.platform === 'linux') {
-        firefoxBinaryPath = 'test_tools/stable/firefox/firefox-bin';
+        firefoxStableBinaryPath = 'test_tools/stable/firefox/firefox-bin';
       } else if (process.platform === 'darwin') {
-        firefoxBinaryPath = 'test_tools/stable/Firefox.app/Contents/MacOS/firefox-bin';
+        firefoxStableBinaryPath = 'test_tools/stable/Firefox.app/Contents/MacOS/firefox-bin';
       }
 
       promises.push(seleniumInit.downloadFirefoxRelease());
@@ -126,8 +126,8 @@ suite('selenium', function() {
     }
 
     try {
-      console.log('Using Firefox: ' + firefoxBinaryPath);
-      console.log('Version: ' + childProcess.execSync(firefoxBinaryPath + ' --version'));
+      console.log('Using Firefox: ' + firefoxStableBinaryPath);
+      console.log('Version: ' + childProcess.execSync(firefoxStableBinaryPath + ' --version'));
       console.log('Beta Version: ' + childProcess.execSync(firefoxBetaBinaryPath + ' --version'));
     } catch (e) {}
 
@@ -156,8 +156,8 @@ suite('selenium', function() {
 
     return Promise.all(promises)
     .then(function() {
-      if (!fs.existsSync(firefoxBinaryPath)) {
-        throw new Error('Firefox binary doesn\'t exist at ' + firefoxBinaryPath + '. Use your installed Firefox binary by setting the FIREFOX environment'.bold.red);
+      if (!fs.existsSync(firefoxStableBinaryPath)) {
+        throw new Error('Firefox binary doesn\'t exist at ' + firefoxStableBinaryPath + '. Use your installed Firefox binary by setting the FIREFOX environment'.bold.red);
       }
 
       if (firefoxBetaBinaryPath && !fs.existsSync(firefoxBetaBinaryPath)) {

--- a/test/testSelenium.js
+++ b/test/testSelenium.js
@@ -254,13 +254,15 @@ suite('selenium', function() {
     });
   }
 
+  /*
+  XXX: Currently broken, see https://github.com/mozilla-services/autopush/issues/426.
   test('send/receive notification with payload & vapid with Firefox Beta', function() {
     return runTest({
       browser: 'firefox-beta',
       payload: 'marco',
       vapid: vapidParam,
     });
-  });
+  });*/
 
   if (process.env.GCM_API_KEY && process.env.TRAVIS_OS_NAME !== 'osx') {
     test('send/receive notification with payload & vapid with Chrome', function() {

--- a/test/testSelenium.js
+++ b/test/testSelenium.js
@@ -142,7 +142,7 @@ suite('selenium', function() {
 
     if (process.env.GCM_API_KEY) {
       chromeBinaryPath = process.env.CHROME;
-      if (!chromeBinaryPath || chromeBinaryPath === 'nightly') {
+      if (chromeBinaryPath === 'nightly') {
         if (process.platform === 'linux') {
           chromeBinaryPath = 'test_tools/chrome-linux/chrome';
         } else if (process.platform === 'darwin') {
@@ -150,7 +150,7 @@ suite('selenium', function() {
         }
 
         promises.push(seleniumInit.downloadChromiumNightly());
-      } else if (chromeBinaryPath === 'stable') {
+      } else if (chromeBinaryPath === 'all') {
         // TODO: Download Chromium release.
         chromeBinaryPath = childProcess.execSync('which chromium-browser').toString().replace('\n', '');
       }

--- a/test/testSelenium.js
+++ b/test/testSelenium.js
@@ -6,6 +6,9 @@ var temp = require('temp').track();
 var colors = require('colors');
 var semver = require('semver');
 var childProcess = require('child_process');
+var webdriver = require('selenium-webdriver');
+var firefox = require('selenium-webdriver/firefox');
+var chrome = require('selenium-webdriver/chrome');
 var seleniumInit = require('./selenium-init');
 var createServer = require('./server');
 var webPush = require('../index.js');
@@ -13,6 +16,8 @@ var webPush = require('../index.js');
 if (!process.env.GCM_API_KEY) {
   console.log('You need to set the GCM_API_KEY env variable to run the tests with Chromium.'.bold.red);
 }
+
+process.env.PATH = process.env.PATH + ':test_tools/';
 
 suite('selenium', function() {
   if (semver.satisfies(process.version, '0.12')) {
@@ -22,19 +27,9 @@ suite('selenium', function() {
 
   this.timeout(180000);
 
-  var firefoxStableBinaryPath, firefoxBetaBinaryPath, chromeBinaryPath;
-
-  process.env.PATH = process.env.PATH + ':test_tools/';
-
-  var webdriver = require('selenium-webdriver'),
-      By = require('selenium-webdriver').By,
-      until = require('selenium-webdriver').until;
-
-  var firefox = require('selenium-webdriver/firefox');
-  var chrome = require('selenium-webdriver/chrome');
-
   var profilePath = temp.mkdirSync('marco');
 
+  var firefoxStableBinaryPath, firefoxBetaBinaryPath, chromeBinaryPath;
   var server, driver;
 
   function runTest(params) {
@@ -98,7 +93,7 @@ suite('selenium', function() {
         go();
       }, server.port);
 
-      return driver.wait(until.titleIs(payload ? payload : 'no payload'), 60000);
+      return driver.wait(webdriver.until.titleIs(payload ? payload : 'no payload'), 60000);
     });
   }
 

--- a/test/testSelenium.js
+++ b/test/testSelenium.js
@@ -31,21 +31,17 @@ suite('selenium', function() {
   var server, driver;
 
   function runTest(params) {
-    var browser = params.browser;
-    var payload = params.payload;
-    var vapid = params.vapid;
-
     var firefoxBinaryPath;
-    if (browser === 'firefox') {
+    if (params.browser === 'firefox') {
       firefoxBinaryPath = firefoxStableBinaryPath
-    } else if (browser === 'firefox-beta') {
-      browser = 'firefox';
+    } else if (params.browser === 'firefox-beta') {
+      params.browser = 'firefox';
       firefoxBinaryPath = firefoxBetaBinaryPath;
     }
 
-    process.env.SELENIUM_BROWSER = browser;
+    process.env.SELENIUM_BROWSER = params.browser;
 
-    return createServer(payload, vapid)
+    return createServer(params.payload, params.vapid)
     .then(function(newServer) {
       server = newServer;
 
@@ -93,7 +89,7 @@ suite('selenium', function() {
         go();
       }, server.port);
 
-      return driver.wait(webdriver.until.titleIs(payload ? payload : 'no payload'), 60000);
+      return driver.wait(webdriver.until.titleIs(params.payload ? params.payload : 'no payload'), 60000);
     });
   }
 


### PR DESCRIPTION
Fixes #111.

`profilePath_` won't be available anymore (https://github.com/SeleniumHQ/selenium/issues/1827), so we have to remove the tests involving a restart of the browser.
It isn't a huge problem, since those tests didn't have a clear value and were hard to maintain.