### PR TITLE
Adds command line executable

### DIFF
--- a/bin/web-push.js
+++ b/bin/web-push.js
@@ -1,10 +1,11 @@
 #! /usr/bin/env node
+const fs = require('fs');
 const webPush = require('web-push');
 webPush.setGCMAPIKey(process.env.GCM_API_KEY);
 
 const argv = require('minimist')(process.argv.slice(2));
 
-const usage = 'Use: web-push --endpoint=<url> --key=<browser key> [--auth=<auth secret>] [--ttl=<seconds>] [--payload=<message>] [--vapid]';
+const usage = 'Use: web-push --endpoint=<url> --key=<browser key> [--auth=<auth secret>] [--ttl=<seconds>] [--payload=<message>] [--vapid-audience] [--vapid-subject] [--vapid-pvtkey] [--vapid-pubkey]';
 
 if (!argv['endpoint'] || !argv['key']) {
   console.log(usage);
@@ -16,18 +17,37 @@ const key = argv['key'];
 const ttl = argv['ttl'] || 0;
 const payload = argv['payload'] || '';
 const auth = argv['auth'] || null;
-const useVAPID = argv['vapid'] || false;
+const vapidAudience = argv['vapid-audience'] || null;
+const vapidSubject = argv['vapid-subject'] || null;
+const vapidPubKey = argv['vapid-pubkey'] || null;
+const vapidPvtKey = argv['vapid-pvtkey'] || null;
+
+function getKeys() {
+  if (vapidPubKey && vapidPvtKey) {
+    const publicKey = fs.readFileSync(argv['vapid-pubkey']);
+    const privateKey = fs.readFileSync(argv['vapid-pvtkey']);
+
+    if (pubKey && pvtKey) {
+      return {
+        privateKey,
+        publicKey
+      };
+    }
+  }
+
+  return webPush.generateVAPIDKeys();
+}
 
 var params = {
   TTL: ttl,
   payload,
   userPublicKey: key
 };
-if (useVAPID) {
-  const vapidKeys = webPush.generateVAPIDKeys();
+if (vapidAudience && vapidSubject) {
+  const vapidKeys = getKeys();
   const vapid = {
-    audience: 'https://www.mozilla.org/',
-    subject: 'mailto:web-push@mozilla.org',
+    audience: vapidAudience,
+    subject: `mailto:${vapidSubject}`,
     privateKey: vapidKeys.privateKey,
     publicKey: vapidKeys.publicKey,
   };

--- a/bin/web-push.js
+++ b/bin/web-push.js
@@ -1,0 +1,46 @@
+#! /usr/bin/env node
+const webPush = require('web-push');
+webPush.setGCMAPIKey(process.env.GCM_API_KEY);
+
+const argv = require('minimist')(process.argv.slice(2));
+
+const usage = 'Use: web-push --endpoint=<url> --key=<browser key> [--auth=<auth secret>] [--ttl=<seconds>] [--payload=<message>]';
+
+if (!argv['endpoint'] || !argv['key']) {
+  console.log(usage);
+  process.exit(1);
+}
+
+const endpoint = argv['endpoint'];
+const key = argv['key'];
+const ttl = argv['ttl'] || 0;
+const payload = argv['payload'] || '';
+const auth = argv['auth'] || null;
+
+// Uses old sendMessage API
+var pushResult = null;
+if (!auth) {
+  pushResult = webPush.sendNotification(endpoint, ttl, key, payload)
+} else {
+  const vapidKeys = webPush.generateVAPIDKeys();
+  const vapid = {
+    audience: 'https://www.mozilla.org/',
+    subject: 'mailto:web-push@mozilla.org',
+    privateKey: vapidKeys.privateKey,
+    publicKey: vapidKeys.publicKey,
+  };
+  pushResult = webPush.sendNotification(endpoint, {
+    TTL: ttl,
+    payload,
+    userPublicKey: key,
+    userAuth: auth,
+    vapid
+  });
+}
+pushResult.then(() => {
+  console.log('Push message sent.');
+}, (err) => {
+  console.log('Error sending push message: ', err);
+}).then(() => {
+  process.exit(0);
+})

--- a/bin/web-push.js
+++ b/bin/web-push.js
@@ -4,7 +4,7 @@ webPush.setGCMAPIKey(process.env.GCM_API_KEY);
 
 const argv = require('minimist')(process.argv.slice(2));
 
-const usage = 'Use: web-push --endpoint=<url> --key=<browser key> [--auth=<auth secret>] [--ttl=<seconds>] [--payload=<message>]';
+const usage = 'Use: web-push --endpoint=<url> --key=<browser key> [--auth=<auth secret>] [--ttl=<seconds>] [--payload=<message>] [--vapid]';
 
 if (!argv['endpoint'] || !argv['key']) {
   console.log(usage);
@@ -16,12 +16,14 @@ const key = argv['key'];
 const ttl = argv['ttl'] || 0;
 const payload = argv['payload'] || '';
 const auth = argv['auth'] || null;
+const useVAPID = argv['vapid'] || false;
 
-// Uses old sendMessage API
-var pushResult = null;
-if (!auth) {
-  pushResult = webPush.sendNotification(endpoint, ttl, key, payload)
-} else {
+var params = {
+  TTL: ttl,
+  payload,
+  userPublicKey: key
+};
+if (useVAPID) {
   const vapidKeys = webPush.generateVAPIDKeys();
   const vapid = {
     audience: 'https://www.mozilla.org/',
@@ -29,18 +31,15 @@ if (!auth) {
     privateKey: vapidKeys.privateKey,
     publicKey: vapidKeys.publicKey,
   };
-  pushResult = webPush.sendNotification(endpoint, {
-    TTL: ttl,
-    payload,
-    userPublicKey: key,
-    userAuth: auth,
-    vapid
-  });
+  params['vapid'] = vapid;
 }
-pushResult.then(() => {
+if (auth) {
+  params['userAuth'] = auth;
+}
+webPush.sendNotification(endpoint, params).then(() => {
   console.log('Push message sent.');
 }, (err) => {
   console.log('Error sending push message: ', err);
 }).then(() => {
   process.exit(0);
-})
+});

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "colors": "^1.1.2",
     "http_ece": "^0.4.5",
     "jws": "^3.1.3",
+    "minimist": "^1.2.0",
     "urlsafe-base64": "^1.0.0"
   },
   "devDependencies": {
@@ -42,5 +43,11 @@
     "selenium-webdriver": "^2.53.1",
     "semver": "^5.1.0",
     "temp": "^0.8.3"
+  },
+  "bin": {
+    "web-push": "bin/web-push.js"
+  },
+  "engines": {
+    "node": ">= v4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "web-push",
-  "version": "2.0.1",
+  "version": "2.0.2",
+  "version": "1.0.3",
   "description": "Web Push library for Node.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "web-push",
   "version": "2.0.2",
-  "version": "1.0.3",
   "description": "Web Push library for Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
vapid and userAuth parameters configurable.

For using vapi add parameter --vapid.
For adding userAuth add parameter --auth=<your auth>

Example:
```bash
web-push --endpoint=https://updates.push.services.mozilla.com/push/v1/gAAAAABW8oWpBwhTzvvSxB-OKwsETosMvOsV75xUGLOQKXckw__twjoNHMIc-OkDljcs2aUaimxjhWUgZRcNZomdzdsgxXlW4dMpCiLzKa72JsQoEfBygiCHlmxxHlPJlimmzFSuk7eP --key=" BHwue1TPjc0sL4tnNway5HnW6qdD9Efi8AgUNyOw0CdUcNe2EvssLlqG8mK6Btc0t3KW9OCgSdJ6RQD6cpouzkY=" --payload="{\"body\":\"Molo mucho\"}"
```