### PR TITLE
Add support for old GCM notification payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,8 +215,10 @@ function sendNotification(endpoint, params) {
         };
         if (encrypted) {
           gcmObj['raw_data'] = encrypted.cipherText.toString('base64');
-        } else {
-          gcmObj.notification = payload;
+        } else if (payload) {
+          for (var item in payload) {
+            gcmObj[item] = payload[item];
+          }
         }
         gcmPayload = JSON.stringify(gcmObj);
 

--- a/index.js
+++ b/index.js
@@ -215,6 +215,8 @@ function sendNotification(endpoint, params) {
         };
         if (encrypted) {
           gcmObj['raw_data'] = encrypted.cipherText.toString('base64');
+        } else {
+          gcmObj.notification = payload;
         }
         gcmPayload = JSON.stringify(gcmObj);
 


### PR DESCRIPTION
This is important for sending unencrypted notifications with title / text.