### PR TITLE
Add support for Node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - DISPLAY=$(if [[ $TRAVIS_OS_NAME == "linux" ]]; then echo ':99.0'; fi)
     - MOZ_XVFB=$(if [[ $TRAVIS_OS_NAME == "linux" ]]; then echo 1; fi)
   matrix:
+    - NODE_VERSION="0.10"
     - NODE_VERSION="0.12"
     - NODE_VERSION="4"
     - NODE_VERSION="stable"
@@ -16,6 +17,8 @@ before_install:
   - nvm install $NODE_VERSION
   - export NODE=$(nvm which $NODE_VERSION)
   - export NPM=${NODE%node}npm
+  - wget http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar
+  - java -jar selenium-server-standalone-2.53.0.jar &> /dev/null &
 install:
   - $NPM install
   - $NPM install mocha

--- a/README.md
+++ b/README.md
@@ -61,6 +61,26 @@ The [Service Worker Cookbook](https://serviceworke.rs/) is full of Web Push exam
 
 ## Running tests
 
+#### Prerequisites:
+  * Java JDK or JRE (http://www.oracle.com/technetwork/java/javase/downloads/index.html)
+  * Selenium Server 2.53.0 ([Download](http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar))
+
+### Setup
+
+* Run Selenium Server
+
+e.g. in shell form:
+
+```sh
+java -jar selenium-server-standalone-2.53.0.jar
+```
+
+To run tests locally with Selenium:
+
+```sh
+npm test
+```
+
 Selenium tests require Firefox or Chromium/Chrome. You can either use your installed versions or let the tests download the browsers for you.
 
 ```

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const https     = require('https');
 const colors    = require('colors');
 const asn1      = require('asn1.js');
 const jws       = require('jws');
+require('./shim');
 
 var ECPrivateKeyASN = asn1.define('ECPrivateKey', function() {
   this.seq().obj(

--- a/package.json
+++ b/package.json
@@ -25,11 +25,17 @@
   },
   "homepage": "https://github.com/marco-c/web-push#readme",
   "dependencies": {
+    "array.prototype.find": "^2.0.0",
     "asn1.js": "^4.5.2",
+    "bluebird": "^3.3.5",
+    "buffer-compare-shim": "^1.0.0",
+    "buffer-equals-polyfill": "^1.0.0",
     "colors": "^1.1.2",
-    "http_ece": "^0.5.0",
+    "create-ecdh": "^4.0.0",
+    "http_ece": "^0.5.1",
     "jws": "^3.1.3",
     "minimist": "^1.2.0",
+    "semver": "^5.1.0",
     "urlsafe-base64": "^1.0.0"
   },
   "devDependencies": {
@@ -40,7 +46,7 @@
     "mocha": "^2.4.5",
     "portfinder": "^1.0.2",
     "request": "^2.69.0",
-    "selenium-webdriver": "^2.53.1",
+    "selenium-webdriver": "~2.47.0",
     "semver": "^5.1.0",
     "temp": "^0.8.3"
   },
@@ -48,6 +54,6 @@
     "web-push": "bin/web-push.js"
   },
   "engines": {
-    "node": ">= v4.0.0"
+    "node": ">= v0.10.0"
   }
 }

--- a/shim.js
+++ b/shim.js
@@ -1,0 +1,10 @@
+var semver = require('semver');
+if (semver.satisfies(process.version, '>= 0.12.0')) {
+  return;
+}
+
+global.Promise = require('bluebird');
+require('array.prototype.find').shim();
+require('buffer-compare-shim');
+require('buffer-equals-polyfill');
+require('crypto').createECDH = require('create-ecdh');

--- a/test/testSelenium.js
+++ b/test/testSelenium.js
@@ -25,11 +25,6 @@ if (!process.env.VAPID_PRIVATE_KEY || !process.env.VAPID_PUBLIC_KEY) {
 process.env.PATH = process.env.PATH + ':test_tools/';
 
 suite('selenium', function() {
-  if (semver.satisfies(process.version, '0.12')) {
-    console.log('selenium-webdriver is incompatible with Node.js v0.12');
-    return;
-  }
-
   var webdriver = require('selenium-webdriver');
   var firefox = require('selenium-webdriver/firefox');
   var chrome = require('selenium-webdriver/chrome');
@@ -50,6 +45,13 @@ suite('selenium', function() {
       params.browser = 'firefox';
       firefoxBinaryPath = firefoxAuroraBinaryPath;
       process.env.SELENIUM_MARIONETTE = true;
+    }
+
+    if (firefoxBinaryPath) {
+      firefoxBinaryPath = path.resolve(firefoxBinaryPath);
+    }
+    if (chromeBinaryPath) {
+      chromeBinaryPath = path.resolve(chromeBinaryPath);
     }
 
     process.env.SELENIUM_BROWSER = params.browser;
@@ -80,6 +82,9 @@ suite('selenium', function() {
         .forBrowser('firefox')
         .setFirefoxOptions(firefoxOptions)
         .setChromeOptions(chromeOptions);
+      if (params.browser !== "chrome") {
+        builder.usingServer('http://localhost:4444/wd/hub');
+      }
       driver = builder.build();
 
       driver.executeScript(function(port) {
@@ -178,7 +183,7 @@ suite('selenium', function() {
 
   teardown(function(done) {
     driver.quit()
-    .catch(function() {})
+    .thenCatch(function() {})
     .then(function() {
       server.close(function() {
         done();


### PR DESCRIPTION
Depends on https://github.com/martinthomson/encrypted-content-encoding/pull/21 to be merged and published to actually work on node 0.10. We will maybe have to bump the http_ece module version in package.json before merging this, depending on the new version number.

I had to use a version of selenium-webdriver that was supported by both Node 0.10 and Node 4.
Sadly it only works with the selenium-server between the browser and the node process.
I don't mind skipping the selenium tests for 0.10 by adding another exception [here](https://github.com/marco-c/web-push/blob/707075d4e20316bea579dc66f7afa230d931e93d/test/testSelenium.js#L28) (but they did help me catch a bug though).