### PR TITLE
Fixes issue where getKeys would always return new VAPID keys

### DIFF
--- a/bin/web-push.js
+++ b/bin/web-push.js
@@ -24,10 +24,10 @@ const vapidPvtKey = argv['vapid-pvtkey'] || null;
 
 function getKeys() {
   if (vapidPubKey && vapidPvtKey) {
-    const publicKey = fs.readFileSync(argv['vapid-pubkey']);
-    const privateKey = fs.readFileSync(argv['vapid-pvtkey']);
+    const publicKey = fs.readFileSync(vapidPubKey);
+    const privateKey = fs.readFileSync(vapidPvtKey);
 
-    if (pubKey && pvtKey) {
+    if (publicKey && privateKey) {
       return {
         privateKey,
         publicKey


### PR DESCRIPTION
Fixes #168 - the variable names were never actually declared so private keys and public keys from the command line would never be used.